### PR TITLE
Don't apply visited link color to dropdown links

### DIFF
--- a/scss/links.scss
+++ b/scss/links.scss
@@ -4,7 +4,7 @@ a {
   &:focus {
     text-decoration: none;
   }
-  &:visited:not(.btn):not(.nav-link) {
+  &:visited:not(.btn):not(.nav-link):not(.dropdown-item) {
     color: $link-visited-color;
     &:hover {
       color: $link-visited-hover-color;
@@ -18,7 +18,7 @@ a {
   &:hover > .panel {
     color: $link-hover-color;
   }
-  &:visited:not(.btn):not(.nav-link) > .panel {
+  &:visited:not(.btn):not(.nav-link):not(.dropdown-item) > .panel {
     color: $link-visited-color;
     &:hover > .panel {
       color: $link-visited-hover-color;


### PR DESCRIPTION
Visited dropdown links don't have the same hover style (color specifically) as non-visited links.

This is a departure from previous styles, and makes for an odd experience when hovering over links (top one is visited):
![image](https://user-images.githubusercontent.com/6179856/156214535-ccc15efd-2fd0-4013-b1f6-7d6ddfa7f11c.png)
